### PR TITLE
including child tasks in Trio measurement

### DIFF
--- a/benchmarks/overhead.py
+++ b/benchmarks/overhead.py
@@ -21,7 +21,7 @@ import trio
 
 from perf_timer import (PerfTimer, ThreadPerfTimer, TrioPerfTimer,
                         AverageObserver, StdDevObserver, HistogramObserver,
-                        measure_overhead)
+                        measure_overhead, TrioHierarchyPerfTimer)
 from perf_timer._impl import _format_duration
 
 
@@ -39,7 +39,7 @@ async def main():
     print()
     print('compare types:')
     observer = default_observer
-    for timer_type in (PerfTimer, ThreadPerfTimer, TrioPerfTimer):
+    for timer_type in (PerfTimer, ThreadPerfTimer, TrioPerfTimer, TrioHierarchyPerfTimer):
         duration = measure_overhead(partial(timer_type, observer=observer))
         item = f'{timer_type.__name__}(observer={observer.__name__}):'
         print(f'    {item:45s}{_format(duration)}')

--- a/src/perf_timer/__init__.py
+++ b/src/perf_timer/__init__.py
@@ -1,7 +1,7 @@
 from ._impl import (PerfTimer, ThreadPerfTimer, AverageObserver,
                     StdDevObserver, HistogramObserver, measure_overhead)
 try:
-    from ._trio import trio_perf_counter, TrioPerfTimer
+    from ._trio import trio_perf_counter, trio_hierarchy_perf_counter, TrioPerfTimer
 except ImportError:
     pass
 from ._version import __version__

--- a/src/perf_timer/__init__.py
+++ b/src/perf_timer/__init__.py
@@ -1,7 +1,8 @@
 from ._impl import (PerfTimer, ThreadPerfTimer, AverageObserver,
                     StdDevObserver, HistogramObserver, measure_overhead)
 try:
-    from ._trio import trio_perf_counter, trio_hierarchy_perf_counter, TrioPerfTimer
+    from ._trio import (trio_perf_counter, trio_hierarchy_perf_counter,
+                        TrioPerfTimer, TrioHierarchyPerfTimer)
 except ImportError:
     pass
 from ._version import __version__

--- a/tests/test_trio.py
+++ b/tests/test_trio.py
@@ -8,7 +8,8 @@ try:
 except ImportError:
     import trio.hazmat as trio_lowlevel
 
-from perf_timer import trio_perf_counter, _trio, TrioPerfTimer, AverageObserver, trio_hierarchy_perf_counter
+from perf_timer import (trio_perf_counter, trio_hierarchy_perf_counter, _trio,
+                        TrioPerfTimer, AverageObserver)
 
 
 async def _work(duration, count=1):
@@ -73,7 +74,7 @@ async def test_trio_perf_counter_time_sleep():
     assert dt == pytest.approx(.5, rel=.15)
 
 
-async def test_trio_perf_counter_child():
+async def test_trio_hierarchy_perf_counter():
     t0 = trio_hierarchy_perf_counter()
     async with trio.open_nursery() as nursery:
         await _work(.05, 3)


### PR DESCRIPTION
add variants of trio_perf_counter() and TrioPerfTimer that include child tasks

TODO: make including child tasks the default

Fixes #8 